### PR TITLE
Make `PDBTools.MacroKeyword`, `PDBTools.Keyword`, `PDBTools.macro_key…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ PDBTools.jl Changelog
 [badge-fix]: https://img.shields.io/badge/Fix-purple.svg
 [badge-info]: https://img.shields.io/badge/Info-gray.svg
 
-Version 3.24.3-DEV
+Version 3.25.0
 --------------
+- ![FEATURE][badge-feature] Make `PDBTools.MacroKeyword`, `PDBTools.Keyword`, `PDBTools.macro_keywords`, and `PDBTools.keyword` public, to allow the user to define custom macros for the selection syntax. 
 
 Version 3.24.2
 --------------

--- a/docs/src/selections.md
+++ b/docs/src/selections.md
@@ -189,6 +189,107 @@ input, and returns `true` or `false` depending on the conditions required for th
     `ishydrophobic`,
     `isnucleoside`,  `ispurine`,      `ispyrimidine`.
 
+## Adding custom keywords and macro-keywords
+
+The selection syntax can be extended with user-defined keywords and macro-keywords.
+This is useful, for example, when atoms carry custom fields (see [Custom fields](@ref custom-atom-fields))
+and you want to select atoms based on those values, or define new short identifier for new
+residue names or combinations of properties.
+
+```@docs
+PDBTools.Keyword
+PDBTools.keywords
+PDBTools.MacroKeyword
+PDBTools.macro_keywords
+``` 
+
+### Custom keywords
+
+A `Keyword` associates a string token with a getter function that extracts a value from
+an atom. Once registered, the keyword supports all comparison operators (`=`, `<`, `>`,
+`<=`, `>=`) as well as implicit equality and multi-value `or` shorthand.
+
+The constructor is:
+
+```julia
+PDBTools.Keyword(ValueType::Type, name::String, getter::Function)
+```
+
+where `ValueType` is the type of the value returned by `getter` (`Int`, `Float64`, or
+`String`), `name` is the token that will appear in the selection string, and `getter` is
+a one-argument function that receives an `Atom` and returns the value.
+
+To register the new keyword, push it into `PDBTools.keywords`:
+
+```julia
+using PDBTools
+
+# Build a vector of atoms that carry a custom "charge" field
+atoms = read_pdb("file.pdb")
+charges = rand(length(atoms))
+atoms_charged = add_custom_field.(atoms, charges)
+
+# Register the new keyword
+push!(PDBTools.keywords, PDBTools.Keyword(Float64, "custom_charge", at -> at.custom))
+
+# Now use it in selections
+select(atoms_charged, "custom_charge < 0.5")
+select(atoms_charged, "custom_charge >= 0.8")
+```
+
+### Custom macro-keywords
+
+A `MacroKeyword` associates a string token with a boolean predicate on an atom.
+Unlike a `Keyword`, it takes no arguments in the selection string — it simply evaluates
+to `true` or `false` for each atom.
+
+The constructor is:
+
+```julia
+PDBTools.MacroKeyword(name::String, getter::Function)
+```
+
+where `name` is the token and `getter` is a one-argument function that receives an `Atom`
+and returns a `Bool`.
+
+To register the new macro-keyword, push it into `PDBTools.macro_keywords`:
+
+```julia
+using PDBTools
+atoms = read_pdb("file.pdb")
+
+# Register a macro keyword that selects glycerol molecules
+push!(PDBTools.macro_keywords, PDBTools.MacroKeyword("glycerol", at -> resname(at) == "GLYC"))
+
+# Use it in selections, alone or combined with other keywords
+select(atoms, "glycerol")
+select(atoms, "glycerol and name O1")
+```
+
+### Combining with custom fields
+
+A common pattern is to attach per-atom numerical data as a custom field and then
+filter with a custom `Keyword`:
+
+```julia
+using PDBTools
+
+atoms = read_pdb("file.pdb")
+scores = rand(length(atoms)) # one score per atom
+atoms_scored = add_custom_field.(atoms, scores)
+
+push!(PDBTools.keywords, PDBTools.Keyword(Float64, "score", at -> at.custom))
+
+high_score = select(atoms_scored, "score > 0.9")
+```
+
+!!! note
+    The custom keywords and macro-keywords added to `PDBTools.keywords` and
+    `PDBTools.macro_keywords` persist for the lifetime of the Julia session.
+    Adding them more than once (e.g. in a loop) will register duplicate entries.
+    Check the current content of the vectors with, for example,
+    `[k.name for k in PDBTools.keywords]` before pushing.
+
 ## Using VMD
 
 [VMD](https://www.ks.uiuc.edu/Research/vmd/) is a very popular and

--- a/src/select/select.jl
+++ b/src/select/select.jl
@@ -4,6 +4,7 @@
 #
 export select, selindex
 export Select, @sel_str
+@compat public MacroKeyword, Keyword, macro_keywords, keywords
 
 """
     Select
@@ -148,7 +149,6 @@ function selindex(set::AbstractVector; by=all)
 end
 
 # Comparison operators
-
 const operators = (
     "=" => (x, y) -> isequal(x, y),
     "<" => (x, y) -> isless(x, y),
@@ -160,12 +160,29 @@ const operators = (
 #
 # Keywords
 #
+"""
+    PDBTools.Keyword(ValueType::Type, name::String, getter::Function)
+
+Structure that defines a keyword of the selection syntax.
+Here we illustrate how to select atom from the definition of a custom
+charge field. 
+
+```julia
+import PDBTools: keywords, Keyword
+charges = rand(length(pdb))
+pdb_charges = add_custom_field.(pdb, charges) # add charge values to custom field
+push!(keywords, Keyword(Float64, "new_charge", at -> at.custom));
+select(pdb_charges, "new_charge < 0.5") # will select all atom custom field < 0.5
+```
+
+"""
 struct Keyword{F<:Function}
     ValueType::Type
     name::String
     getter::F
     operators::Tuple
 end
+Keyword(T::Type, name::String, getter::Function) = Keyword(T, name, getter, operators)
 
 function (key::Keyword)(s::AbstractVector{<:AbstractString})
     (; getter, operators) = key
@@ -181,6 +198,24 @@ end
 #
 # Macro keywords (functions without parameters)
 #
+"""
+    PDBTools.MacroKeyword(name::String, getter::Function)
+
+Structrure that carries the string name and function that defines a macro keyword for 
+string selection syntax. 
+
+To add a new string macro keyword, use, for example:
+
+```julia
+import PDBTools: macro_keywords, MacroKeyword
+push!(macro_keywords, MacroKeyword("glycerol", at -> resname(at) == "GLYC"));
+select(pdb, "glycerol") # will select all atoms with resname == GLYC
+```
+
+where we added the "glycerol" macro to the selection syntax, associated with the 
+`at -> resname(at) == "GLYC"` function.
+
+"""
 struct MacroKeyword{F<:Function}
     name::String
     getter::F
@@ -210,24 +245,38 @@ end
 #
 # Keywords for PDBTools
 #
+"""
+    PDBTools.keywords
+
+Vector of `Keyword` objects, defining the the string macros of the selection syntax.
+Can be incremented by `push!`ing new `Keyword` objects. 
+
+"""
 const keywords = [
-    Keyword(Int, "index", index, operators),
-    Keyword(Int, "index_pdb", index_pdb, operators),
-    Keyword(Int, "resnum", resnum, operators),
-    Keyword(Int, "residue", residue, operators),
-    Keyword(Float64, "beta", beta, operators),
-    Keyword(Float64, "occup", occup, operators),
-    Keyword(Float64, "x", at -> getfield(at, :x), operators),
-    Keyword(Float64, "y", at -> getfield(at, :y), operators),
-    Keyword(Float64, "z", at -> getfield(at, :z), operators),
-    Keyword(Int, "model", model, operators),
-    Keyword(String, "name", name, operators),
-    Keyword(String, "segname", segname, operators),
-    Keyword(String, "resname", resname, operators),
-    Keyword(String, "chain", chain, operators),
-    Keyword(String, "element", element, operators),
+    Keyword(Int, "index", index),
+    Keyword(Int, "index_pdb", index_pdb),
+    Keyword(Int, "resnum", resnum),
+    Keyword(Int, "residue", residue),
+    Keyword(Float64, "beta", beta),
+    Keyword(Float64, "occup", occup),
+    Keyword(Float64, "x", at -> getfield(at, :x)),
+    Keyword(Float64, "y", at -> getfield(at, :y)),
+    Keyword(Float64, "z", at -> getfield(at, :z)),
+    Keyword(Int, "model", model),
+    Keyword(String, "name", name),
+    Keyword(String, "segname", segname),
+    Keyword(String, "resname", resname),
+    Keyword(String, "chain", chain),
+    Keyword(String, "element", element),
 ]
 
+"""
+    PDBTools.macro_keywords
+
+Vector of `MacroKeyword` objects, defining the the string macros of the selection syntax.
+Can be incremented by `push!`ing new `MacroKeyword` objects. 
+
+"""
 const macro_keywords = [
     MacroKeyword("water", iswater),
     MacroKeyword("protein", isprotein),
@@ -645,5 +694,12 @@ end
     @test resname.(eachresidue(lessresidues)) == ["ALA", "CYS", "SER", "SER"]
     @test chain.(eachresidue(lessresidues)) == ["A", "A", "A", "A"]
     @test model.(eachresidue(lessresidues)) == [1, 1, 1, 1]
+
+    # Add custom keywords and macro_keywords
+    pdb_c = [ add_custom_field(at, name(at) == "CA" ? 1.0 : 0.0) for at in atoms] 
+    push!(PDBTools.keywords, PDBTools.Keyword(Float64, "new_charge", at -> at.custom))
+    @test length(select(pdb_c, "new_charge > 0.5")) == 104
+    push!(PDBTools.macro_keywords, PDBTools.MacroKeyword("new_charged", at -> at.custom > 0.0))
+    @test (length(select(pdb_c, "new_charged"))) == 104
 
 end # testitem


### PR DESCRIPTION
…words`, and `PDBTools.keyword` public, to allow the user to define custom macros for the selection syntax.